### PR TITLE
[wip] Use the operation objects for the messages

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
@@ -137,7 +137,7 @@ cdef class _AioCall:
             for operation in all_operations:
                 operation.un_c()
 
-            return receive_message_operation._message
+            return receive_message_operation.message()
 
         finally:
             grpc_call_unref(call)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/aio/call.pyx.pxi
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 cimport cpython
-from grpc._cython import cygrpc
 
 _EMPTY_FLAGS = 0
 _EMPTY_METADATA = ()
@@ -65,6 +64,13 @@ cdef class _AioCall:
         cdef grpc_slice method_slice
         cdef grpc_op * ops
 
+        cdef Operation initial_metadata_operation
+        cdef Operation send_message_operation
+        cdef Operation send_close_from_client_operation
+        cdef Operation receive_initial_metadata_operation
+        cdef Operation receive_message_operation
+        cdef Operation receive_status_on_client_operation
+
         cdef grpc_call_error call_status
 
 
@@ -88,27 +94,27 @@ cdef class _AioCall:
 
         ops = <grpc_op *>gpr_malloc(sizeof(grpc_op) * self._OP_ARRAY_LENGTH)
 
-        initial_metadata_operation = cygrpc.SendInitialMetadataOperation(_EMPTY_METADATA, GRPC_INITIAL_METADATA_USED_MASK)
+        initial_metadata_operation = SendInitialMetadataOperation(_EMPTY_METADATA, GRPC_INITIAL_METADATA_USED_MASK)
         initial_metadata_operation.c()
         ops[0] = <grpc_op> initial_metadata_operation.c_op
 
-        send_message_operation = cygrpc.SendMessageOperation(request, _EMPTY_FLAGS)
+        send_message_operation = SendMessageOperation(request, _EMPTY_FLAGS)
         send_message_operation.c()
         ops[1] = <grpc_op> send_message_operation.c_op
 
-        send_close_from_client_operation = cygrpc.SendCloseFromClientOperation(_EMPTY_FLAGS)
+        send_close_from_client_operation = SendCloseFromClientOperation(_EMPTY_FLAGS)
         send_close_from_client_operation.c()
         ops[2] = <grpc_op> send_close_from_client_operation.c_op
 
-        receive_initial_metadata_operation = cygrpc.ReceiveInitialMetadataOperation(_EMPTY_FLAGS)
+        receive_initial_metadata_operation = ReceiveInitialMetadataOperation(_EMPTY_FLAGS)
         receive_initial_metadata_operation.c()
         ops[3] = <grpc_op> receive_initial_metadata_operation.c_op
 
-        receive_message_operation = cygrpc.ReceiveMessageOperation(_EMPTY_FLAGS)
+        receive_message_operation = ReceiveMessageOperation(_EMPTY_FLAGS)
         receive_message_operation.c()
         ops[4] = <grpc_op> receive_message_operation.c_op
 
-        receive_status_on_client_operation = cygrpc.ReceiveStatusOnClientOperation(_EMPTY_FLAGS)
+        receive_status_on_client_operation = ReceiveStatusOnClientOperation(_EMPTY_FLAGS)
         receive_status_on_client_operation.c()
         ops[5] = <grpc_op> receive_status_on_client_operation.c_op
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/operation.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/operation.pyx.pxi
@@ -1,4 +1,4 @@
-# Copyright 2017 gRPC authors.
+# Copyright 2019 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Tests passing, refactor is successful
```
python src/python/grpcio_tests/tests/aio/end2end/test_client.py                

test_unary_unary (__main__.TestClient) ... TypeError: 'NotImplementedType' object is not callable
Exception ignored in: 'grpc._cython.cygrpc.asyncio_socket_shutdown'
TypeError: 'NotImplementedType' object is not callable
ok

----------------------------------------------------------------------
Ran 1 test in 0.149s

OK
```