### PR TITLE
A patch to make the testing framework work in Google

### DIFF
--- a/src/python/grpcio_tests/tests_aio/unit/sync_server.py
+++ b/src/python/grpcio_tests/tests_aio/unit/sync_server.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import subprocess
-import sys
+import argparse
 
 from concurrent import futures
 from time import sleep
@@ -23,57 +21,30 @@ import grpc
 from src.proto.grpc.testing import messages_pb2
 from src.proto.grpc.testing import test_pb2_grpc
 
+
 # TODO (https://github.com/grpc/grpc/issues/19762)
 # Change for an asynchronous server version once it's implemented.
-
-
 class TestServiceServicer(test_pb2_grpc.TestServiceServicer):
 
     def UnaryCall(self, request, context):
         return messages_pb2.SimpleResponse()
 
 
-class Server:
-    """
-    Synchronous server is executed in another process which initializes
-    implicitly the grpc using the synchronous configuration. Both worlds
-    can not coexist within the same process.
-    """
-
-    def __init__(self, host_and_port):  # pylint: disable=W0621
-        self._host_and_port = host_and_port
-        self._handle = None
-
-    def start(self):
-        assert self._handle is None
-
-        filename = os.path.abspath(__file__)
-        args = ["python", filename, self._host_and_port]
-        self._handle = subprocess.Popen(args)
-
-    def terminate(self):
-        if not self._handle:
-            return
-
-        self._handle.terminate()
-        self._handle = None
-
-
 if __name__ == "__main__":
-    try:
-        host_and_port = sys.argv[1]
-    except IndexError:
-        print("Missing host_and_port argument, like localhost:3333")
-        sys.exit(1)
+    parser = argparse.ArgumentParser(description='Synchronous gRPC server.')
+    parser.add_argument(
+        '--host_and_port',
+        required=True,
+        type=str,
+        nargs=1,
+        help='the host and port to listen.')
+    args = parser.parse_args()
 
     server = grpc.server(
         futures.ThreadPoolExecutor(max_workers=1),
         options=(('grpc.so_reuseport', 1),))
     test_pb2_grpc.add_TestServiceServicer_to_server(TestServiceServicer(),
                                                     server)
-    server.add_insecure_port(host_and_port)
+    server.add_insecure_port(args.host_and_port[0])
     server.start()
-    try:
-        sleep(3600)
-    finally:
-        server.stop(None)
+    server.wait_for_termination()

--- a/src/python/grpcio_tests/tests_aio/unit/test_base.py
+++ b/src/python/grpcio_tests/tests_aio/unit/test_base.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import sys
+import subprocess
+
 import asyncio
 import unittest
 import socket
@@ -35,11 +39,50 @@ def _get_free_loopback_tcp_port():
     return tcp_socket, "%s:%s" % (host_target, address_tuple[1])
 
 
+class _Server:
+    """_Server is an wrapper for a sync-server subprocess.
+
+    The synchronous server is executed in another process which initializes
+    implicitly the grpc using the synchronous configuration. Both worlds
+    can not coexist within the same process.
+    """
+
+    def __init__(self, host_and_port):  # pylint: disable=W0621
+        self._host_and_port = host_and_port
+        self._handle = None
+
+    def start(self):
+        assert self._handle is None
+
+        try:
+            from google3.pyglib import resources
+            executable = resources.GetResourceFilename(
+                "google3/third_party/py/grpc/sync_server")
+            args = [executable, '--host_and_port', self._host_and_port]
+        except ImportError:
+            executable = sys.executable
+            directory, _ = os.path.split(os.path.abspath(__file__))
+            filename = directory + '/sync_server.py'
+            args = [
+                executable, filename, '--host_and_port', self._host_and_port
+            ]
+
+        self._handle = subprocess.Popen(args)
+
+    def terminate(self):
+        if not self._handle:
+            return
+
+        self._handle.terminate()
+        self._handle.wait()
+        self._handle = None
+
+
 class AioTestBase(unittest.TestCase):
 
     def setUp(self):
         self._socket, self._target = _get_free_loopback_tcp_port()
-        self._server = sync_server.Server(self._target)
+        self._server = _Server(self._target)
         self._server.start()
         self._loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self._loop)


### PR DESCRIPTION
* Sync server itself is an application, so it will be invoked in `subprocess` but not be imported;
* `Server` class moved to `test_base.py`;
* Add a `wait()` before test case `tearDown`;
* Make the `subprocess` mechanism work in Google.

PTAL @pfreixes @gnossen

I manually tested this change in google3, Bazel, `run_tests.py`, hope it doesn't break anything.

Related PR: https://github.com/grpc/grpc/pull/19960